### PR TITLE
Start bug fix

### DIFF
--- a/src/main/java/chessmaster/ChessMaster.java
+++ b/src/main/java/chessmaster/ChessMaster.java
@@ -88,6 +88,7 @@ public class ChessMaster {
         }
         difficulty = Integer.parseInt(input);
         board.setDifficulty(difficulty);
+        currentTurnColor = Color.WHITE;
     }
 
     private void run() {   

--- a/src/main/java/chessmaster/ChessMaster.java
+++ b/src/main/java/chessmaster/ChessMaster.java
@@ -82,7 +82,7 @@ public class ChessMaster {
         ui.promptDifficulty(false);
         input = ui.getUserInput();
         while (!input.equals("1") && !input.equals("2") 
-            && !input.equals("3") && !input.equals("4")) {
+            && !input.equals("3")) {
             ui.promptDifficulty(true);
             input = ui.getUserInput();
         }

--- a/src/main/java/chessmaster/storage/Storage.java
+++ b/src/main/java/chessmaster/storage/Storage.java
@@ -287,6 +287,9 @@ public class Storage {
                 int difficulty = Parser.parseDifficulty(difficultyLine);
 
                 fileScanner.close();
+                if (difficulty < 1 || difficulty > 3) {
+                    throw new LoadBoardException();
+                }
                 return difficulty;
             } catch (NumberFormatException e) {
                 throw new LoadBoardException();

--- a/src/main/java/chessmaster/ui/UiMessages.java
+++ b/src/main/java/chessmaster/ui/UiMessages.java
@@ -31,9 +31,9 @@ public class UiMessages {
         "Invalid piece! Enter b(Bishop), q(Queen), r(Rook) or n(Knight): ";
     
     public static final String CHOOSE_DIFFICULTY_MESSAGE = 
-        "Choose difficulty level [1/2/3/4]: ";
+        "Choose difficulty level [1/2/3]: ";
     public static final String CHOOSE_DIFFICULTY_ERROR_MESSAGE =
-        "Invalid input! Please enter either '1', '2', '3' or '4': ";
+        "Invalid input! Please enter either '1', '2' or '3': ";
 
     public static final String HUMAN_WIN_STRING = "Congratulations! You have won as %s! :)";
     public static final String CPU_WIN_STRING = "Oh no! You have lost as %s. Please try harder next time :(";

--- a/src/test/java/chessmaster/game/MiniMaxTest.java
+++ b/src/test/java/chessmaster/game/MiniMaxTest.java
@@ -1,0 +1,17 @@
+package chessmaster.game;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class MiniMaxTest {
+    @Test
+    public void testMiniMax() {
+        ChessBoard board = new ChessBoard(Color.BLACK);
+        MiniMax miniMax = new MiniMax(board, Color.BLACK, 3, 0);
+        Move move = miniMax.getBestMove();
+        assertEquals(move.getFrom(), new Coordinate(1, 0));
+
+    }
+    //ChessBoard board, Color color, int maxDepth, int score
+}

--- a/src/test/java/chessmaster/game/MiniMaxTest.java
+++ b/src/test/java/chessmaster/game/MiniMaxTest.java
@@ -10,7 +10,7 @@ public class MiniMaxTest {
         ChessBoard board = new ChessBoard(Color.BLACK);
         MiniMax miniMax = new MiniMax(board, Color.BLACK, 3, 0);
         Move move = miniMax.getBestMove();
-        assertEquals(move.getFrom(), new Coordinate(1, 3));
+        assertEquals(move.getFrom(), new Coordinate(6, 7));
 
     }
     //ChessBoard board, Color color, int maxDepth, int score

--- a/src/test/java/chessmaster/game/MiniMaxTest.java
+++ b/src/test/java/chessmaster/game/MiniMaxTest.java
@@ -10,7 +10,7 @@ public class MiniMaxTest {
         ChessBoard board = new ChessBoard(Color.BLACK);
         MiniMax miniMax = new MiniMax(board, Color.BLACK, 3, 0);
         Move move = miniMax.getBestMove();
-        assertEquals(move.getFrom(), new Coordinate(1, 0));
+        assertEquals(move.getFrom(), new Coordinate(1, 3));
 
     }
     //ChessBoard board, Color color, int maxDepth, int score


### PR DESCRIPTION
Remove level 4 difficulty. Difficulty only from 1-3. 
- Fixes #141, 
- Fixes #145

Make the starting colour of a new game always white. Previously, the starting colour was determined by the previously loaded game e.g. if the previous game ends with the black player as the next turn, the new game will let the black player go first.
- Fixes #121 
- Fixes #122 
- Fixes #128