### PR TITLE
Fix empty payload in moves command

### DIFF
--- a/src/main/java/chessmaster/commands/ShowMovesCommand.java
+++ b/src/main/java/chessmaster/commands/ShowMovesCommand.java
@@ -9,7 +9,13 @@ import chessmaster.pieces.ChessPiece;
 import chessmaster.ui.TextUI;
 
 public class ShowMovesCommand extends Command {
-    public static final String SHOW_MOVE_COMMAND_STRING = "moves";
+    public static final String SHOW_MOVES_COMMAND_STRING = "moves";
+
+    public static final String NO_COORDINATE_FOUND_STRING = 
+        "Oops! Looks like you forgot to specify a coordinate!";
+    public static final String SHOW_MOVES_FORMAT_STRING = "Format: moves [column][row]";
+    public static final String SHOW_MOVES_EXAMPLE_STRING = "Example: moves a2";
+
     private String userInput;
     private ChessPiece piece;
 
@@ -19,6 +25,11 @@ public class ShowMovesCommand extends Command {
 
     @Override
     public CommandResult execute(ChessBoard board, TextUI ui) throws ChessMasterException {
+        if (userInput.isBlank()) {
+            return new CommandResult(NO_COORDINATE_FOUND_STRING, 
+                SHOW_MOVES_FORMAT_STRING, SHOW_MOVES_EXAMPLE_STRING);
+        }
+
         Coordinate coord = Coordinate.parseAlgebraicCoor(userInput);
         piece = board.getPieceAtCoor(coord);
         if (piece.isEmptyPiece()) {

--- a/src/main/java/chessmaster/parser/Parser.java
+++ b/src/main/java/chessmaster/parser/Parser.java
@@ -138,10 +138,11 @@ public class Parser {
     public static Command parseCommand(String in) {
         String[] splitInputStrings = in.split("\\s+", 2);
         String commandString = splitInputStrings[0];
+        String payload = splitInputStrings.length > 1 ? splitInputStrings[1] : ""; // Remaining input text
 
         switch (commandString) {
-        case ShowMovesCommand.SHOW_MOVE_COMMAND_STRING:
-            return new ShowMovesCommand(splitInputStrings[1]);
+        case ShowMovesCommand.SHOW_MOVES_COMMAND_STRING:
+            return new ShowMovesCommand(payload);
         case ShowCommand.SHOW_COMAMND_STRING:
             return new ShowCommand();
         case RulesCommand.RULES_COMAMND_STRING:

--- a/src/main/java/chessmaster/pieces/ChessPiece.java
+++ b/src/main/java/chessmaster/pieces/ChessPiece.java
@@ -33,7 +33,10 @@ public abstract class ChessPiece {
     protected static final int[] DOWN_LEFT = {1, 1}; 
     protected static final int[] DOWN_RIGHT = {-1, 1};
 
-    protected static final String[] NO_AVAILABLE_MOVES_STRING = {"There aren't any moves available for this piece!"};
+    protected static final String NO_AVAILABLE_MOVES_STRING = 
+        "There aren't any moves available for %s at %s!";
+    protected static final String AVAILABLE_MOVES_STRING = 
+        "Available coordinates for %s at %s: ";
 
     protected Color color;
     protected Coordinate position;
@@ -125,10 +128,11 @@ public abstract class ChessPiece {
         StringBuilder out = new StringBuilder();
         Coordinate[][] availableCoordinates = getAvailableCoordinates(board);
 
-        if (Arrays.stream(availableCoordinates).allMatch(
-                x -> x.length == 0
-        )) {
-            return NO_AVAILABLE_MOVES_STRING;
+        boolean isEmpty = Arrays.stream(availableCoordinates).allMatch(x -> x.length == 0);
+        if (isEmpty) {
+            return new String[] {
+                String.format(NO_AVAILABLE_MOVES_STRING, getPieceName(), this.position)
+            };
         }
 
         for (Coordinate[] direction : availableCoordinates) {
@@ -138,7 +142,7 @@ public abstract class ChessPiece {
         }
 
         return new String[] {
-            String.format("Available coordinates for %s at %s: ", getPieceName(), this.position),
+            String.format(AVAILABLE_MOVES_STRING, getPieceName(), this.position),
             out.toString()
         };
 


### PR DESCRIPTION
ChessMaster crashes if no coordinate is given followed by moves command. 
Added check for empty payload. Fixes #119
![image](https://github.com/AY2324S1-CS2113-T18-1/tp/assets/20199469/2f8169c9-c197-4d83-b93b-f1af6c16f45a)
