### PR TITLE
Add invalid command

### DIFF
--- a/src/main/java/chessmaster/commands/InvalidCommand.java
+++ b/src/main/java/chessmaster/commands/InvalidCommand.java
@@ -1,0 +1,17 @@
+package chessmaster.commands;
+
+import chessmaster.game.ChessBoard;
+import chessmaster.ui.TextUI;
+
+public class InvalidCommand extends Command {
+
+    private static final String INVALID_COMMAND_STRING = 
+        "Oops! It appears that the command you entered is not recognized. " + System.lineSeparator() + 
+        "Please use 'help' to view a list of available commands.";
+
+    @Override
+    public CommandResult execute(ChessBoard board, TextUI ui) {
+        return new CommandResult(INVALID_COMMAND_STRING);
+    }
+    
+}

--- a/src/main/java/chessmaster/commands/MoveCommand.java
+++ b/src/main/java/chessmaster/commands/MoveCommand.java
@@ -11,6 +11,15 @@ import chessmaster.ui.TextUI;
 public class MoveCommand extends Command {
 
     public static final String MOVE_COMAMND_STRING = "move";
+    
+    public static final String NO_MOVE_FOUND_STRING = 
+        "Oops! It seems you forgot to provide the 'from' and 'to' squares!";
+    public static final String MOVE_FORMAT_STRING = 
+        "Format: moves <from> <to>";
+    public static final String MOVE_EXAMPLE_STRING = "Example: move e2 e4";
+
+    private static final String EMPTY_PAYLOAD_ERROR_STRING = NO_MOVE_FOUND_STRING + System.lineSeparator() + 
+        MOVE_FORMAT_STRING + System.lineSeparator() + MOVE_EXAMPLE_STRING;
     private static final String MOVE_PIECE_MESSAGE = "You moved %s from %s to %s";
 
     private String userInput;
@@ -30,6 +39,10 @@ public class MoveCommand extends Command {
      */
     @Override
     public CommandResult execute(ChessBoard board, TextUI ui) throws ChessMasterException {
+        if (userInput.isBlank()) {
+            throw new InvalidMoveException(EMPTY_PAYLOAD_ERROR_STRING);
+        }
+        
         move = Parser.parseMove(userInput, board);
         if (!move.isValid(board)) {
             throw new InvalidMoveException();

--- a/src/main/java/chessmaster/commands/ShowMovesCommand.java
+++ b/src/main/java/chessmaster/commands/ShowMovesCommand.java
@@ -33,7 +33,7 @@ public class ShowMovesCommand extends Command {
         Coordinate coord = Coordinate.parseAlgebraicCoor(userInput);
         piece = board.getPieceAtCoor(coord);
         if (piece.isEmptyPiece()) {
-            throw new NullPieceException();
+            throw new NullPieceException(coord);
         }
 
         Coordinate[] possibleCoordinates = piece.getFlattenedCoordinates(board);

--- a/src/main/java/chessmaster/exceptions/NullPieceException.java
+++ b/src/main/java/chessmaster/exceptions/NullPieceException.java
@@ -1,11 +1,14 @@
 //@@author TongZhengHong
 package chessmaster.exceptions;
 
+import chessmaster.game.Coordinate;
 import chessmaster.ui.ExceptionMessages;
 
 public class NullPieceException extends ChessMasterException {
-    public NullPieceException() {
-        super(ExceptionMessages.MESSAGE_NULL_PIECE_EXCEPTION);
+
+    public NullPieceException(Coordinate coordinate) {
+        super(String.format(ExceptionMessages.MESSAGE_NULL_PIECE_COORDINATE_EXCEPTION, 
+            coordinate.toString()));
     }
 
     public NullPieceException(String message) {

--- a/src/main/java/chessmaster/parser/Parser.java
+++ b/src/main/java/chessmaster/parser/Parser.java
@@ -3,6 +3,7 @@ package chessmaster.parser;
 import chessmaster.commands.AbortCommand;
 import chessmaster.commands.Command;
 import chessmaster.commands.HelpCommand;
+import chessmaster.commands.InvalidCommand;
 import chessmaster.commands.MoveCommand;
 import chessmaster.commands.RulesCommand;
 import chessmaster.commands.ShowCommand;
@@ -82,7 +83,7 @@ public class Parser {
 
         ChessPiece relevantPiece = board.getPieceAtCoor(from);
         if (relevantPiece.isEmptyPiece()) {
-            throw new NullPieceException();
+            throw new NullPieceException(from);
         } else if (board.isPieceOpponent(relevantPiece)) {
             throw new MoveOpponentPieceException();
         }
@@ -141,6 +142,8 @@ public class Parser {
         String payload = splitInputStrings.length > 1 ? splitInputStrings[1] : ""; // Remaining input text
 
         switch (commandString) {
+        case MoveCommand.MOVE_COMAMND_STRING:
+            return new MoveCommand(payload);
         case ShowMovesCommand.SHOW_MOVES_COMMAND_STRING:
             return new ShowMovesCommand(payload);
         case ShowCommand.SHOW_COMAMND_STRING:
@@ -153,9 +156,8 @@ public class Parser {
             return new LegendCommand();
         case AbortCommand.ABORT_COMAMND_STRING:
             return new AbortCommand();
-
         default:
-            return new MoveCommand(in);
+            return new InvalidCommand();
         }
     }
 

--- a/src/main/java/chessmaster/ui/ExceptionMessages.java
+++ b/src/main/java/chessmaster/ui/ExceptionMessages.java
@@ -7,6 +7,8 @@ public class ExceptionMessages {
     public static final String MESSAGE_LOAD_BOARD_EXCEPTION = "Unable to load board!";
     public static final String MESSAGE_INVALID_MOVE_EXCEPTION = "Oops, that move isn't valid!";
     public static final String MESSAGE_NULL_PIECE_EXCEPTION = "No chess piece found at coordinate!";
+    public static final String MESSAGE_NULL_PIECE_COORDINATE_EXCEPTION = 
+        "No chess piece found at coordinate %s!";
     public static final String MESSAGE_MOVE_OPPONENT_EXCEPTION = "You have chosen an opponent piece! "
             + "Please choose your pieces!";
     public static final String MESSAGE_PARSE_COLOR_EXCEPTION = "Unable to parse color!";


### PR DESCRIPTION
Add the `move` command tag to execute moves and `InvalidCommand` when the user enters any other inputs. 
- Fixes #120 
- Fixes #135

A valid move requires a `move` tag in front to be recognized
![image](https://github.com/AY2324S1-CS2113-T18-1/tp/assets/20199469/939ed81f-85ce-40c6-8eb1-c1a881505d9b)

Old move syntax will be recognized as an invalid command and the user will be prompted to use `help`
![image](https://github.com/AY2324S1-CS2113-T18-1/tp/assets/20199469/ba2b4e4d-1638-47be-9f67-6441334e2abf)
