### PR TITLE
Refactor `ChessPiece` processing functions

### DIFF
--- a/src/main/java/chessmaster/game/ChessBoard.java
+++ b/src/main/java/chessmaster/game/ChessBoard.java
@@ -102,17 +102,7 @@ public class ChessBoard {
         return this.difficulty;
     }
 
-    public boolean isChecked(Color color) {
-        Move[] moves = getAllMoves(color.getOppositeColour());
-        for (Move move : moves) {
-            Coordinate to = move.getTo();
-            if (this.getPieceAtCoor(to) instanceof King) {
-                return true;
-            }
-        }
-        return false;
-    }
-
+    //@@author onx001
     public boolean hasEnPassant() {
         //Checks all chess pieces for en passant
         for (int row = 0; row < ChessBoard.SIZE; row++) {
@@ -163,8 +153,40 @@ public class ChessBoard {
         return moves.length == 0;
     }
 
+    /**
+     * Check if the player of the specified color is in check.
+     *
+     * This method determines whether the player with the specified color is in check, 
+     * meaning their king is under threat. It checks if any moves by the opposing player's pieces 
+     * can reach the player's king.
+     *
+     * @param color The color for which to check if the king is in check ('WHITE' or 'BLACK').
+     * @return `true` if the player is in check; `false` if the player's king is not in immediate danger.
+     */
+    public boolean isChecked(Color color) {
+        Move[] moves = getPseudoLegalMoves(color.getOppositeColour());
+        for (Move move : moves) {
+            Coordinate to = move.getTo();
+            if (this.getPieceAtCoor(to) instanceof King) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-    public Move[] getAllMoves(Color color) {
+    /**
+     * Retrieve an array of pseudo-legal moves for pieces of the specified color.
+     *
+     * This method calculates and provides an array of pseudo-legal moves for all pieces of the given 
+     * color on the chessboard. Pseudo-legal moves are those that are valid based on the piece's movement rules, 
+     * but they may not account for potential checks on the king.
+     *
+     * @param color The color for which pseudo-legal moves should be generated ('WHITE' or 'BLACK').
+     * @return An array of Move objects, each representing a pseudo-legal move, containing the starting square, 
+     *          destination square, and the ChessPiece involved.
+     */
+
+    public Move[] getPseudoLegalMoves(Color color) {
         //Declare arraylist of moves as allMoves
         ArrayList<Move> allMoves = new ArrayList<>();
 
@@ -184,9 +206,24 @@ public class ChessBoard {
         return allMoves.toArray(new Move[0]);
     }
 
+    /**
+     * Retrieve an array of legal moves for pieces of the specified color.
+     *
+     * This method calculates and provides an array of legal moves for all pieces of the given color on the 
+     * chessboard. This is done by executing each pseudo-legal move and ensuring that it does not result in 
+     * the king being checked. 
+     * 
+     * Legal moves are those that adhere to the piece's movement rules and do not result in the 
+     * player's own king being in check.
+     *
+     * @param color The color for which legal moves should be generated ('WHITE' or 'BLACK').
+     * @return An array of Move objects, each representing a legal move, containing the starting square, 
+     *          destination square, and the ChessPiece involved.
+     */
     public Move[] getLegalMoves(Color color) {
-        Move[] moves = getAllMoves(color);
-        ArrayList<Move> uncheckedMoves = new ArrayList<>();
+        Move[] moves = getPseudoLegalMoves(color);
+        ArrayList<Move> legalMoves = new ArrayList<>();
+
         for (Move move : moves) {
             ChessBoard newBoard = this.clone();
             Coordinate from = move.getFrom();
@@ -198,10 +235,10 @@ public class ChessBoard {
                 continue;
             }
             if (!newBoard.isChecked(color)) {
-                uncheckedMoves.add(move);
+                legalMoves.add(move);
             }
         }
-        return uncheckedMoves.toArray(new Move[0]);
+        return legalMoves.toArray(new Move[0]);
     }
 
     //@@author TongZhengHong
@@ -287,7 +324,7 @@ public class ChessBoard {
                 enPassantPiece.setIsCaptured();
             }
         } else if (move.isSkippingPawn()) {
-            move.getPiece().setEnPassant();
+            move.getPieceMoved().setEnPassant();
         }
 
         //clear all en passants
@@ -295,7 +332,7 @@ public class ChessBoard {
             for (int col = 0; col < ChessBoard.SIZE; col++) {
                 Coordinate coor = new Coordinate(col, row);
                 ChessPiece piece = getPieceAtCoor(coor);
-                if (piece.isEnPassant() && piece.getColor() != move.getPiece().getColor()) {
+                if (piece.isEnPassant() && piece.getColor() != move.getPieceMoved().getColor()) {
                     piece.clearEnPassant();
 
                 }

--- a/src/main/java/chessmaster/game/ChessBoard.java
+++ b/src/main/java/chessmaster/game/ChessBoard.java
@@ -196,7 +196,7 @@ public class ChessBoard {
                 ChessPiece piece = getPieceAtCoor(currentCoor);
 
                 if (piece.isSameColorAs(color)) {
-                    Coordinate[] possibleCoordinates = piece.getLegalCoordinates(this);
+                    Coordinate[] possibleCoordinates = piece.getPseudoLegalCoordinates(this);
                     for (Coordinate possible: possibleCoordinates) {
                         allMoves.add(MoveFactory.createMove(this, currentCoor, possible));
                     }

--- a/src/main/java/chessmaster/game/Move.java
+++ b/src/main/java/chessmaster/game/Move.java
@@ -73,12 +73,10 @@ public class Move {
      * @return
      */
     public boolean isValid(ChessBoard board) {
-        Coordinate[][] coordinates = pieceMoved.getPseudoCoordinates(board);
-        for (Coordinate[] direction : coordinates) {
-            for (Coordinate coor : direction) {
-                if (coor.equals(to)) {
-                    return true;
-                }
+        Coordinate[] coordinates = pieceMoved.getPseudoLegalCoordinates(board);
+        for (Coordinate coor : coordinates) {
+            if (coor.equals(to)) {
+                return true;
             }
         }
         return false;
@@ -126,7 +124,7 @@ public class Move {
     }
 
     public boolean isSkippingPawn() {
-        if (!(piece instanceof Pawn)) {
+        if (!(pieceMoved instanceof Pawn)) {
             return false;
         }
 
@@ -148,7 +146,10 @@ public class Move {
     public boolean equals(Object obj) {
         if (obj != null && obj instanceof Move) {
             final Move other = (Move) obj;
-            return from.equals(other.getFrom()) && to.equals(other.getTo()) && pieceMoved.equals(other.getPieceMoved());
+            boolean sameFrom = from.equals(other.getFrom());
+            boolean sameTo = to.equals(other.getTo());
+            boolean samePiece = pieceMoved.getPieceName().equals(other.getPieceMoved().getPieceName());
+            return sameFrom && sameTo && samePiece;
         }
         return false;
     }

--- a/src/main/java/chessmaster/pieces/Bishop.java
+++ b/src/main/java/chessmaster/pieces/Bishop.java
@@ -39,7 +39,7 @@ public class Bishop extends ChessPiece {
      *     is of the coordinates in that direction.
      */
     @Override
-    public Coordinate[][] getPseudoCoordinates(ChessBoard board) {
+    public Coordinate[] getPseudoLegalCoordinates(ChessBoard board) {
         Coordinate[][] result = new Coordinate[DIRECTIONS.length][0];
 
         for (int dir = 0; dir < DIRECTIONS.length; dir++) {
@@ -68,7 +68,7 @@ public class Bishop extends ChessPiece {
             result[dir] = possibleCoordInDirection.toArray(new Coordinate[0]);
         }
 
-        return result;
+        return flattenArray(result);
     }
 
     @Override

--- a/src/main/java/chessmaster/pieces/EmptyPiece.java
+++ b/src/main/java/chessmaster/pieces/EmptyPiece.java
@@ -13,8 +13,8 @@ public class EmptyPiece extends ChessPiece {
     }
 
     @Override
-    public Coordinate[][] getPseudoCoordinates(ChessBoard board) {
-        return new Coordinate[0][];
+    public Coordinate[] getPseudoLegalCoordinates(ChessBoard board) {
+        return new Coordinate[0];
     }
 
     // An empty piece will never be moved

--- a/src/main/java/chessmaster/pieces/King.java
+++ b/src/main/java/chessmaster/pieces/King.java
@@ -33,7 +33,7 @@ public class King extends ChessPiece {
     }
     
     @Override
-    public Coordinate[][] getPseudoCoordinates(ChessBoard board) {
+    public Coordinate[] getPseudoLegalCoordinates(ChessBoard board) {
         Coordinate[][] result = new Coordinate[DIRECTIONS.length][0];
 
         for (int dir = 0; dir < DIRECTIONS.length; dir++) {
@@ -82,7 +82,7 @@ public class King extends ChessPiece {
             }
         }
 
-        return result;
+        return flattenArray(result);
     }
 
     @Override

--- a/src/main/java/chessmaster/pieces/Knight.java
+++ b/src/main/java/chessmaster/pieces/Knight.java
@@ -37,7 +37,7 @@ public class Knight extends ChessPiece {
     }
 
     @Override
-    public Coordinate[][] getPseudoCoordinates(ChessBoard board) {
+    public Coordinate[] getPseudoLegalCoordinates(ChessBoard board) {
         Coordinate[][] result = new Coordinate[DIRECTIONS.length][0];
 
         for (int dir = 0; dir < DIRECTIONS.length; dir++) {
@@ -56,7 +56,7 @@ public class Knight extends ChessPiece {
             }
         }
 
-        return result;
+        return flattenArray(result);
     }
 
 }

--- a/src/main/java/chessmaster/pieces/Pawn.java
+++ b/src/main/java/chessmaster/pieces/Pawn.java
@@ -35,9 +35,10 @@ public class Pawn extends ChessPiece {
     }
 
     @Override
-    public Coordinate[][] getPseudoCoordinates(ChessBoard board) {
+    public Coordinate[] getPseudoLegalCoordinates(ChessBoard board) {
         Coordinate[][] result = new Coordinate[DIRECTIONS_UP.length][0];
         int[][] directions = board.isPieceFriendly(this) ? DIRECTIONS_UP : DIRECTIONS_DOWN;
+        
         boolean canEnPassant = false;
         Coordinate enPassantCoor = null;
 
@@ -91,7 +92,7 @@ public class Pawn extends ChessPiece {
             }
         }
 
-        return result;
+        return flattenArray(result);
     }
 
     @Override

--- a/src/main/java/chessmaster/pieces/Queen.java
+++ b/src/main/java/chessmaster/pieces/Queen.java
@@ -33,7 +33,7 @@ public class Queen extends ChessPiece {
     }
 
     @Override
-    public Coordinate[][] getPseudoCoordinates(ChessBoard board) {
+    public Coordinate[] getPseudoLegalCoordinates(ChessBoard board) {
         Coordinate[][] result = new Coordinate[DIRECTIONS.length][0];
 
         for (int dir = 0; dir < DIRECTIONS.length; dir++) {
@@ -63,7 +63,7 @@ public class Queen extends ChessPiece {
             result[dir] = possibleCoordInDirection.toArray(new Coordinate[0]);
         }
 
-        return result;
+        return flattenArray(result);
     }
 
     @Override

--- a/src/main/java/chessmaster/pieces/Rook.java
+++ b/src/main/java/chessmaster/pieces/Rook.java
@@ -33,7 +33,7 @@ public class Rook extends ChessPiece {
     }
 
     @Override
-    public Coordinate[][] getPseudoCoordinates(ChessBoard board) {
+    public Coordinate[] getPseudoLegalCoordinates(ChessBoard board) {
         Coordinate[][] result = new Coordinate[DIRECTIONS.length][0];
 
         for (int dir = 0; dir < DIRECTIONS.length; dir++) {
@@ -63,7 +63,7 @@ public class Rook extends ChessPiece {
             result[dir] = possibleCoordInDirection.toArray(new Coordinate[0]);
         }
 
-        return result;
+        return flattenArray(result);
     }
 
     @Override

--- a/src/main/java/chessmaster/storage/Storage.java
+++ b/src/main/java/chessmaster/storage/Storage.java
@@ -214,7 +214,7 @@ public class Storage {
                                   ChessBoard otherBoard,
                                   Human human,
                                   CPU cpu) throws ChessMasterException {
-        ArrayList moveStringList = new ArrayList<String>();
+        ArrayList<String> moveStringList = new ArrayList<String>();
         ArrayList<String> humanMoves = loadHumanMoves();
         ArrayList<String> cpuMoves = loadCPUMoves();
 
@@ -410,7 +410,7 @@ public class Storage {
             }
         }
 
-        ArrayList out = new ArrayList<String>();
+        ArrayList<String> out = new ArrayList<String>();
         if (fileScanner.hasNext()) {
             String[] movesArray = fileScanner.nextLine().split(", ");
             Arrays.stream(movesArray)
@@ -419,6 +419,7 @@ public class Storage {
                     .forEach(x -> out.add(x));
         }
 
+        fileScanner.close();
         return out;
     }
 
@@ -439,7 +440,7 @@ public class Storage {
             }
         }
 
-        ArrayList out = new ArrayList<String>();
+        ArrayList<String> out = new ArrayList<String>();
         if (fileScanner.hasNext()) {
             String[] movesArray = fileScanner.nextLine().split(", ");
             Arrays.stream(movesArray)
@@ -448,6 +449,7 @@ public class Storage {
                     .forEach(x -> out.add(x));
         }
 
+        fileScanner.close();
         return out;
     }
 


### PR DESCRIPTION
Previously, we had
- `getAvailableCoordinates`: returns a 2D array of pseudo-legal coordinates a piece can go to
- `getFilteredCoordinates`: returns a 1D array of pseudo-legal coordinates a piece can go to

For more clarity, this PR will implement the following new methods

ChessPiece.java: 
- `getPseudoLegalCoordinates`: returns a 1D array of **pseudo-legal** coordinates a piece can go to
- `getLegalCoordinates`: returns a 1D array of **legal** coordinates a piece can go to
- `flattenArray`: Take a 2D array of `Coordinate` and convert it into a 1D array (for utility purposes)

ChessBoard.java:
- `getPseuoLegalMoves`: returns an array of all **pseudo-legal** `move` objects a color can make
- `getLegalMoves`: returns an array of all **legal** `move` objects a color can make