### PR TITLE
Ignore empty spaces in each `nextLine` method in `Storage` class

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -636,6 +636,21 @@ Every time a turn ends, ChessMaster will save the current state of the game. Whe
 user will be prompted to choose whether to load the saved game or begin a new one. ChessMaster only supports a single
 saved game, and starting a new one will delete the existing save file.
 
+### Editing the storage file
+Tasks data are saved automatically in a text (.txt) file `<JAR file location>/data/ChessMaster.txt`. Users are welcome to update data directly by editing this data file to achieve a desired game state. 
+
+The format of the saved game in the storage file is as follows:
+
+```json
+[CURRENT_PLAYER_COLOR]  // Either BLACK or WHITE
+[GAME_DIFFICULTY]       // Integer from 1 - 3
+[NEXT_TURN_COLOR]       // Either BLACK or WHITE
+[HUMAN_MOVE_HISTORY]    // delimited by ','
+[CPU_MOVE_HISTORY]      // delimited by ','
+[CHESS_BOARD_PIECE]     // Next 8 lines of 8 characters each
+[hasMoved_FLAGS]        // Next 8 lines of 8 characters each
+```
+
 ## FAQ
 
 > **Q**: How do I transfer my data to another computer? 

--- a/src/main/java/chessmaster/game/Game.java
+++ b/src/main/java/chessmaster/game/Game.java
@@ -32,7 +32,6 @@ public class Game {
 
     private Command command;
     private boolean hasEnded;
-    private boolean exit = false;
 
     public Game(Color playerColour, Color currentTurnColor, ChessBoard board, 
         Storage storage, TextUI ui, int difficulty, Human human, CPU cpu) {

--- a/src/main/java/chessmaster/storage/Storage.java
+++ b/src/main/java/chessmaster/storage/Storage.java
@@ -11,7 +11,7 @@ import chessmaster.parser.Parser;
 import chessmaster.pieces.ChessPiece;
 import chessmaster.user.CPU;
 import chessmaster.user.Human;
-
+import chessmaster.user.Player;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -167,7 +167,7 @@ public class Storage {
         int rowIndex = 0;
         ChessTile[][] boardTiles = new ChessTile[ChessBoard.SIZE][ChessBoard.SIZE];
         while (rowIndex < ChessBoard.SIZE && fileScanner.hasNext()) {
-            String chessRowLine = fileScanner.nextLine();
+            String chessRowLine = fileScanner.nextLine().trim();
             if (chessRowLine.length() != ChessBoard.SIZE) {
                 fileScanner.close();
                 throw new LoadBoardException();
@@ -195,7 +195,7 @@ public class Storage {
 
         rowIndex = 0;
         while (rowIndex < ChessBoard.SIZE && fileScanner.hasNext()) {
-            String chessRowLine = fileScanner.nextLine();
+            String chessRowLine = fileScanner.nextLine().trim();
             if (chessRowLine.length() != ChessBoard.SIZE) {
                 fileScanner.close();
                 throw new LoadBoardException();
@@ -231,7 +231,7 @@ public class Storage {
                                   ChessBoard board,
                                   Human human,
                                   CPU cpu) throws ChessMasterException {
-        ArrayList<String> moveStringList = new ArrayList();
+        ArrayList<String> moveStringList = new ArrayList<String>();
         ArrayList<String> humanMoves = loadHumanMoves();
         ArrayList<String> cpuMoves = loadCPUMoves();
 
@@ -287,7 +287,7 @@ public class Storage {
 
 
     //@@author onx001
-    private boolean isPieceValid (ChessPiece initialPiece) {
+    private boolean isPieceValid(ChessPiece initialPiece) {
         if (initialPiece.isBlackKing()) {
             if (blackKingPresent) {
                 return false;
@@ -339,8 +339,8 @@ public class Storage {
         }
 
         if (fileScanner.hasNext()) {
-            String colorLine = fileScanner.nextLine();
-            Color playerColor = Parser.parsePlayerColor(colorLine);
+            String colorLine = fileScanner.nextLine().trim();
+            Color playerColor = Parser.parsePlayerColor(colorLine.toUpperCase());
 
             fileScanner.close();
             return playerColor;
@@ -373,7 +373,7 @@ public class Storage {
 
         if (fileScanner.hasNext()) {
             try {
-                String difficultyLine = fileScanner.nextLine();
+                String difficultyLine = fileScanner.nextLine().trim();
                 int difficulty = Parser.parseDifficulty(difficultyLine);
 
                 fileScanner.close();
@@ -414,8 +414,8 @@ public class Storage {
         }
 
         if (fileScanner.hasNext()) {
-            String currentColorString = fileScanner.nextLine();
-            Color color = Parser.parsePlayerColor(currentColorString);
+            String currentColorString = fileScanner.nextLine().trim();
+            Color color = Parser.parsePlayerColor(currentColorString.toUpperCase());
             fileScanner.close();
             return color;
         }
@@ -455,11 +455,12 @@ public class Storage {
 
         ArrayList<String> out = new ArrayList<String>();
         if (fileScanner.hasNext()) {
-            String[] movesArray = fileScanner.nextLine().split(", ");
+            String movesString = fileScanner.nextLine().trim();
+            String[] movesArray = movesString.split(Player.MOVE_DELIMITER);
             Arrays.stream(movesArray)
                     .sequential()
                     .filter(x -> !x.equals(""))
-                    .forEach(x -> out.add(x));
+                    .forEach(x -> out.add(x.trim()));
         }
 
         fileScanner.close();
@@ -492,11 +493,12 @@ public class Storage {
 
         ArrayList<String> out = new ArrayList<String>();
         if (fileScanner.hasNext()) {
-            String[] movesArray = fileScanner.nextLine().split(", ");
+            String movesString = fileScanner.nextLine().trim();
+            String[] movesArray = movesString.split(Player.MOVE_DELIMITER);
             Arrays.stream(movesArray)
                     .sequential()
                     .filter(x -> !x.equals(""))
-                    .forEach(x -> out.add(x));
+                    .forEach(x -> out.add(x.trim()));
         }
 
         fileScanner.close();

--- a/src/main/java/chessmaster/ui/UiMessages.java
+++ b/src/main/java/chessmaster/ui/UiMessages.java
@@ -17,7 +17,8 @@ public class UiMessages {
         "Invalid input! Please enter either 'y' for yes or 'n' for no: ";
     public static final String CONTINUE_PREV_GAME_MESSAGE = "Great! Continuing previous game as %s at difficulty %d";
 
-    public static final String CHOOSE_PLAYER_COLOR_MESSAGE = "Choose your starting color to start new game! [b/w/exit]";
+    public static final String CHOOSE_PLAYER_COLOR_MESSAGE = 
+        "Choose your starting color to start new game! [b/w/exit] ";
     public static final String CHOOSE_PLAYER_COLOR_ERROR_MESSAGE = 
         "Invalid input! Please enter either 'b' for Black or 'w' for White: ";
     public static final String START_NEW_GAME_MESSAGE = "Great! Starting new game as %s";

--- a/src/main/java/chessmaster/user/Player.java
+++ b/src/main/java/chessmaster/user/Player.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 
 public abstract class Player {
 
-    private static final String MOVE_DELIMITER = ", ";
+    public static final String MOVE_DELIMITER = ",";
 
     protected ArrayList<Move> moves;
     protected ArrayList<ChessPiece> pieces;


### PR DESCRIPTION
Lines in the storage file with additional spaces cannot be parsed correctly.
Added fix to trim any empty spaces in each line and between delimiters